### PR TITLE
IP allowed regions set in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ env:
   TF_VAR_wcu: 1
   TF_VAR_ip_address: true
   TF_VAR_ip_time_limit: "3"
-  TF_VAR_allowed_regions: ${{ secrets.ALLOWED_REGIONS }}
+  TF_VAR_allowed_regions: "['eu-west-1', 'eu-west-2', 'us-east-1']"
   TF_VAR_scan_schedule: "5 minutes"
   TF_VAR_update_schedule: "5 minutes"
   TF_VAR_ip_scan_schedule: "5 minutes"

--- a/docs/REPO.md
+++ b/docs/REPO.md
@@ -48,8 +48,8 @@ Environment variables should be created as secrets where:
 ```
 TF_VAR_cloudflare: true
 TF_VAR_cf_api_key: ${{ secrets.CF_API_KEY }}
-TF_VAR_ip_address: true
-TF_VAR_allowed_regions: ${{ secrets.ALLOWED_REGIONS }}
+TF_VAR_hackerone: "enabled"
+TF_VAR_hackerone_api_token: ${{ secrets.HACKERONE_API_TOKEN }}
 ```
 * similarly if you want to use the standard DynamoDB database sizing (recommended), delete these lines:
 ```


### PR DESCRIPTION
Set IP allowed regions in workflow environment variables, rather than as a GitHub Actions Secret.
This is due to issues with entering a string representation of a list as a secret.