### PR TITLE
chore: pin action to latest ref (dev)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: domain-protect/domain-protect
-          ref: refs/heads/main
+          ref: refs/tags/v0.4.8
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: domain-protect/domain-protect
-          ref: refs/tags/v0.4.8
+          ref: refs/tags/0.4.8
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5


### PR DESCRIPTION
## what
- pin action to latest ref (dev)

## why
- Best practices in case a breaking change is introduced in domain-protect

## references
- https://github.com/domain-protect/domain-protect/releases/tag/0.4.8