### PR TITLE
fix: pin action to latest ref (prd)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: domain-protect/domain-protect
-          ref: refs/heads/main
+          ref: refs/tags/0.4.8
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## what
- pin action to latest ref (prd)

## why
- Best practices in case a breaking change is introduced in domain-protect

## references
- https://github.com/domain-protect/domain-protect/releases/tag/0.4.8
- Previous PR #19 