### PR TITLE
fix: use env vars for domain-protect, tf, and python

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
 name: Deploy Domain Protect
+
 on:
   workflow_dispatch:
   push:
@@ -26,6 +27,10 @@ env:
   TF_VAR_hackerone: "enabled"
   TF_VAR_hackerone_api_token: ${{ secrets.HACKERONE_API_TOKEN }}
   TF_VAR_region: ${{ secrets.AWS_REGION }}
+  TF_CLI_ARGS_init: "-backend-config=bucket=${{ secrets.TERRAFORM_STATE_BUCKET }} -backend-config=key=${{ secrets.TERRAFORM_STATE_KEY }} -backend-config=region=${{ secrets.TERRAFORM_STATE_REGION }}"
+  DOMAIN_PROTECT_VERSION: "0.4.8"
+  TERRAFORM_VERSION: "1.4.6"
+  PYTHON_VERSION: "3.11"
 
 jobs:
   terraform_plan_apply_dev:
@@ -42,18 +47,18 @@ jobs:
       - name: Terraform setup
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.4.6
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       - name: checkout Domain Protect
         uses: actions/checkout@v4
         with:
           repository: domain-protect/domain-protect
-          ref: refs/tags/0.4.8
+          ref: refs/tags/${{ env.DOMAIN_PROTECT_VERSION }}
 
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
@@ -64,15 +69,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN}}
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Terraform initialise
-        run: >
-          terraform init 
-          -backend-config=bucket=${{ secrets.TERRAFORM_STATE_BUCKET}} 
-          -backend-config=key=${{ secrets.TERRAFORM_STATE_KEY}} 
-          -backend-config=region=${{ secrets.TERRAFORM_STATE_REGION}}
 
       - name: set Terraform dev workspace
         run: |
@@ -107,26 +105,19 @@ jobs:
       - name: Terraform setup
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.4.6
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       - name: checkout Domain Protect
         uses: actions/checkout@v4
         with:
           repository: domain-protect/domain-protect
-          ref: refs/tags/0.4.8
+          ref: refs/tags/${{ env.DOMAIN_PROTECT_VERSION }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN}}
           aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Terraform initialise
-        run: >
-          terraform init 
-          -backend-config=bucket=${{ secrets.TERRAFORM_STATE_BUCKET}} 
-          -backend-config=key=${{ secrets.TERRAFORM_STATE_KEY}} 
-          -backend-config=region=${{ secrets.TERRAFORM_STATE_REGION}}
 
       - name: set Terraform prd workspace
         run: |
@@ -166,18 +157,18 @@ jobs:
       - name: Terraform setup
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.4.6
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       - name: checkout Domain Protect
         uses: actions/checkout@v4
         with:
           repository: domain-protect/domain-protect
-          ref: refs/heads/main
+          ref: refs/tags/${{ env.DOMAIN_PROTECT_VERSION }}
 
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
@@ -190,13 +181,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN}}
           aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Terraform initialise
-        run: >
-          terraform init 
-          -backend-config=bucket=${{ secrets.TERRAFORM_STATE_BUCKET}} 
-          -backend-config=key=${{ secrets.TERRAFORM_STATE_KEY}} 
-          -backend-config=region=${{ secrets.TERRAFORM_STATE_REGION}}
 
       - name: set Terraform prd workspace
         run: terraform workspace select prd


### PR DESCRIPTION
## what
- use env vars for domain-protect, tf, and python

## why
- Previously missed one more hard coded copy pasta ref to `refs/head/main`
- Switch from using `terraform init` to `TF_CLI_ARGS_init` env var which is available in the existing `1.4.x` pinned version of terraform

## references
- Previous PR #20 
- https://developer.hashicorp.com/terraform/cli/v1.4.x/config/environment-variables#tf_cli_args-and-tf_cli_args_name
