### PR TITLE
chore: correct multi-line syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,7 +183,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: set Terraform prd workspace
-        run: >
+        run: |
           terraform init
           terraform workspace select prd
 


### PR DESCRIPTION
Replace `>` with `|` for multiline syntax in GitHub Actions